### PR TITLE
Feature/ruler colours

### DIFF
--- a/packages/xenpaper-ui/src/Sidebars.tsx
+++ b/packages/xenpaper-ui/src/Sidebars.tsx
@@ -29,7 +29,7 @@ const Flink = styled.a`
 export const Footer = styled(props => {
     return <Box px={3} py={2} {...props}>
         <Text as="div" color="text.placeholder">
-            <Flink href="#">Xenpaper</Flink> <Flink target="_blank" href="https://github.com/dxinteractive/xenpaper/releases">(v1.6.0)</Flink> is made by <Flink target="_blank" href="https://damienclarke.me">Damien Clarke</Flink> using <Flink target="_blank" href="https://www.typescriptlang.org/">typescript</Flink>, <Flink target="_blank" href="https://reactjs.org/">react</Flink>, <Flink target="_blank" href="https://tonejs.github.io/">tonejs</Flink>, <Flink target="_blank" href="https://github.com/dmaevsky/rd-parse">rd-parse</Flink>, <Flink target="_blank" href="https://styled-components.com/">styled-components</Flink> and <Flink target="_blank" href="https://dendriform.xyz">dendriform</Flink>.
+            <Flink href="#">Xenpaper</Flink> <Flink target="_blank" href="https://github.com/dxinteractive/xenpaper/releases">(v1.7.0)</Flink> is made by <Flink target="_blank" href="https://damienclarke.me">Damien Clarke</Flink> using <Flink target="_blank" href="https://www.typescriptlang.org/">typescript</Flink>, <Flink target="_blank" href="https://reactjs.org/">react</Flink>, <Flink target="_blank" href="https://tonejs.github.io/">tonejs</Flink>, <Flink target="_blank" href="https://github.com/dmaevsky/rd-parse">rd-parse</Flink>, <Flink target="_blank" href="https://styled-components.com/">styled-components</Flink> and <Flink target="_blank" href="https://dendriform.xyz">dendriform</Flink>.
         </Text>
     </Box>;
 })`
@@ -213,7 +213,7 @@ type SidebarProps = {
 
 export const Sidebar = (props: SidebarProps): React.ReactElement => {
     const {setSidebar, children, title, desc, pad} = props;
-    return <TextPanel width={['100rem', '20rem', '30rem', '40%']} flexDirection="column" flexShrink="0" minHeight="0">
+    return <TextPanel width={['auto', '20rem', '30rem', '40%']} flexDirection="column" flexShrink="0" minHeight="0" height={['66vh', 'auto']}>
         <Box position={["absolute", "fixed"]} top={0} right={0} pt={3} pr={3}>
             <IconToggle
                 state="cross"


### PR DESCRIPTION
- Fix sidebar on mobile, is now not stupidly wide
- Added ability to choose colouring of plotted scales based on proximity
  - Really need some more keywords to get large amounts of notes plotted easily, like `all` or `arp`, `5limit`, `22::44` etc